### PR TITLE
Adding secure connection to fonts

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -28,7 +28,7 @@
 
 	<!-- Custom styles for this template -->
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}static/css/main.css" />
-	<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,200bold,400old" />
+	<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,200bold,400old" />
 	<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css" />
   <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}static/css/syntax.css" />
 


### PR DESCRIPTION
Chrome has changed their security settings to disallow mixed-security type resources from loading. The fonts no longer load on chrome due to this missing character :). 

BTW, great template! I love it. It was just what I was looking for- clean & simple.